### PR TITLE
Update test path with data/ for kv-2

### DIFF
--- a/example-secret.yaml
+++ b/example-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: example-secret
   annotations:
-    avp_path: "avp/test"
+    avp_path: "avp/data/test"
 type: Opaque
 data:
   sample-secret: <sample>


### PR DESCRIPTION
When using the kv2 engine the secrets data is inside a data/ path

I could only get the example to work after setting the path to `avp/data/test`, after updating the plugin to v0.4.0 I noticed the new documentation saying v2 was the default (but I was trying with v1)