### PR TITLE
Updates to the annotations to match the latest changes to the plugin

### DIFF
--- a/example-secret.yaml
+++ b/example-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: example-secret
   annotations:
-    avp_path: "avp/data/test"
+    avp.kubernetes.io/path: "avp/data/test"
 type: Opaque
 stringData:
   sample-secret: <sample>

--- a/example-secret.yaml
+++ b/example-secret.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-secret
   annotations:
     avp.kubernetes.io/path: "avp/data/test"
+    avp.kubernetes.io/kv-version: "2"
 type: Opaque
 stringData:
   sample-secret: <sample>


### PR DESCRIPTION
Through my testing, it seemed that I needed to explicitly mention the KV version "2" and a change to the avp_path annotation was required to match the plugin's requirements as well as the docs.